### PR TITLE
fix: if x-api-key is empty, it allows to acceess

### DIFF
--- a/fastapi_key_auth/middleware/authorizer.py
+++ b/fastapi_key_auth/middleware/authorizer.py
@@ -23,7 +23,7 @@ class Authenticator:
         return api_keys
 
     def authenticate(self, conn: HTTPConnection) -> bool:
-        if "x-api-key" not in conn.headers:
+        if "x-api-key" not in conn.headers or not conn.headers["x-api-key"]:
             raise AuthenticationError("no api key")
 
         api_key = conn.headers["x-api-key"]


### PR DESCRIPTION
This pull request addresses a key handling issue in the `fastapi-key-auth` library. Specifically, the current implementation allows access when the `x-api-key` is empty. This pull request contains the necessary changes to fix this issue.